### PR TITLE
Issue #6 Adding option to 'transform-runtime' plugin to avoid getting…

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -19,7 +19,7 @@ const config = {
             'transform-decorators-legacy',
             'transform-class-properties',
             'transform-object-rest-spread',
-            'transform-runtime'
+            ['transform-runtime', {helpers: false, polyfill: false, regenerator: true}]
           ]
         }
       },


### PR DESCRIPTION
… 'Uncaught TypeError: $export is not a function' message.
Trying close issue #6 

This most probably happens on updated browsers, while not on older ones.
I'm not 100% all options I added are actually needed to be redefined, however everything seems to be working just fine with this change, I don't know ```babel``` or ```babel-loader``` so well, so not sure if/how this effects the code exactly.